### PR TITLE
VOLO: 'NameError: name 'reload_model_weights' is not defined

### DIFF
--- a/keras_cv_attention_models/volo/volo.py
+++ b/keras_cv_attention_models/volo/volo.py
@@ -408,6 +408,10 @@ def VOLO(
 
     if num_classes == 0:
         model = tf.keras.models.Model(inputs, nn, name=model_name)
+        pre_resolutions = PRETRAINED_DICT[model.name]
+        max_resolution = max([int(ii) for ii in pre_resolutions.keys()])
+        request_resolution = input_shape[0] if str(input_shape[0]) in pre_resolutions else max_resolution
+        pretrained = str(request_resolution) if pretrained is not None else None
         reload_model_weights(model, pretrained_dict=PRETRAINED_DICT, sub_release="volo", input_shape=input_shape, pretrained=pretrained)
         return model
 

--- a/keras_cv_attention_models/volo/volo.py
+++ b/keras_cv_attention_models/volo/volo.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import backend as K
-from keras_cv_attention_models.download_and_load import reload_model_weights_with_mismatch
+from keras_cv_attention_models.download_and_load import reload_model_weights_with_mismatch, reload_model_weights
 from keras_cv_attention_models.attention_layers import batchnorm_with_activation, conv2d_no_bias
 
 

--- a/keras_cv_attention_models/volo/volo.py
+++ b/keras_cv_attention_models/volo/volo.py
@@ -408,7 +408,7 @@ def VOLO(
 
     if num_classes == 0:
         model = tf.keras.models.Model(inputs, nn, name=model_name)
-        reload_model_weights(model, input_shape, pretrained)
+        reload_model_weights(model, pretrained_dict=PRETRAINED_DICT, sub_release="volo", input_shape=input_shape, pretrained=pretrained)
         return model
 
     _, height, width, channel = nn.shape


### PR DESCRIPTION
First of all, Thanks for this amazing repo. :) 

Trying `VOLO` with `num_classess=0` yields`NameError: name 'reload_model_weights' is not defined`. This pull request should solve this issue.

* issue: https://colab.research.google.com/drive/1cMyyNHKA3HnPxSm9rzR112qOMkizE-__?usp=sharing
* fixed: https://colab.research.google.com/drive/1GHjA3e0ngcrWAE1B5R5fwZcFDZlXIU2h?usp=sharing




