### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,12 @@ setup(
     keywords="tensorflow keras cv attention pretrained models",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["tensorflow-macos", "tensorflow-addons", "tensorflow-datasets"],
+    install_requires=[
+        "tensorflow-macos;platform_system=='Darwin'",
+        "tensorflow;platform_system!='Darwin'",
+        "tensorflow-addons",
+        "tensorflow-datasets"
+    ],
     python_requires=">=3.6",
     license="Apache 2.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     keywords="tensorflow keras cv attention pretrained models",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["tensorflow", "tensorflow-addons", "tensorflow-datasets"],
+    install_requires=["tensorflow-macos", "tensorflow-addons", "tensorflow-datasets"],
     python_requires=">=3.6",
     license="Apache 2.0",
 )


### PR DESCRIPTION
Thank you very much for this very nice Python Package. I recently updated to a MacBook Pro with M1 Chips. To have better performance, Apple recommends installing `tensorflow-macos` and not `tensorflow`. Your requirements require users to have `tensorflow` installed which leads to the following behavior on my side: 

```

% pip install -U keras-cv-attention-models

>>> 
Collecting keras-cv-attention-models
  Using cached keras_cv_attention_models-1.2.4-py3-none-any.whl (388 kB)
Requirement already satisfied: tensorflow-addons in /Users/davidcleres/miniforge3/envs/resmonics-m1/lib/python3.9/site-packages (from keras-cv-attention-models) (0.16.1)
Collecting tensorflow-datasets
  Using cached tensorflow_datasets-4.5.2-py3-none-any.whl (4.2 MB)
Collecting keras-cv-attention-models
  Using cached keras_cv_attention_models-1.2.3-py3-none-any.whl (383 kB)
  Using cached keras_cv_attention_models-1.2.2-py3-none-any.whl (380 kB)
  Using cached keras_cv_attention_models-1.2.1-py3-none-any.whl (378 kB)
  Using cached keras_cv_attention_models-1.2.0-py3-none-any.whl (370 kB)
  Using cached keras_cv_attention_models-1.1.20-py3-none-any.whl (364 kB)
  Using cached keras_cv_attention_models-1.1.19-py3-none-any.whl (363 kB)
  Using cached keras_cv_attention_models-1.1.18-py3-none-any.whl (363 kB)
  Using cached keras_cv_attention_models-1.1.17-py3-none-any.whl (362 kB)
  Using cached keras_cv_attention_models-1.1.16-py3-none-any.whl (357 kB)
  Using cached keras_cv_attention_models-1.1.15-py3-none-any.whl (349 kB)
  Using cached keras_cv_attention_models-1.1.14-py3-none-any.whl (163 kB)
  Using cached keras_cv_attention_models-1.1.13-py3-none-any.whl (162 kB)
  Using cached keras_cv_attention_models-1.1.12-py3-none-any.whl (162 kB)
  Using cached keras_cv_attention_models-1.1.11-py3-none-any.whl (164 kB)
  Using cached keras_cv_attention_models-1.1.10-py3-none-any.whl (164 kB)
  Using cached keras_cv_attention_models-1.1.9-py3-none-any.whl (144 kB)
  Using cached keras_cv_attention_models-1.1.8-py3-none-any.whl (142 kB)
  Using cached keras_cv_attention_models-1.1.7-py3-none-any.whl (140 kB)
  Using cached keras_cv_attention_models-1.1.6-py3-none-any.whl (139 kB)
  Using cached keras_cv_attention_models-1.1.5-py3-none-any.whl (138 kB)
  Using cached keras_cv_attention_models-1.1.4-py3-none-any.whl (138 kB)
  Using cached keras_cv_attention_models-1.1.3-py3-none-any.whl (137 kB)
  Using cached keras_cv_attention_models-1.1.2-py3-none-any.whl (135 kB)
  Using cached keras_cv_attention_models-1.1.1-py3-none-any.whl (134 kB)
  Using cached keras_cv_attention_models-1.1.0-py3-none-any.whl (134 kB)
  Using cached keras_cv_attention_models-1.0.22-py3-none-any.whl (130 kB)
  Using cached keras_cv_attention_models-1.0.21-py3-none-any.whl (130 kB)
  Using cached keras_cv_attention_models-1.0.20-py3-none-any.whl (129 kB)
Collecting einops
  Using cached einops-0.4.0-py3-none-any.whl (28 kB)
Collecting keras-cv-attention-models
  Using cached keras_cv_attention_models-1.0.19-py3-none-any.whl (123 kB)
  Using cached keras_cv_attention_models-1.0.18-py3-none-any.whl (123 kB)
  Using cached keras_cv_attention_models-1.0.17-py3-none-any.whl (121 kB)
  Using cached keras_cv_attention_models-1.0.16-py3-none-any.whl (117 kB)
  Using cached keras_cv_attention_models-1.0.15-py3-none-any.whl (119 kB)
  Using cached keras_cv_attention_models-1.0.14-py3-none-any.whl (119 kB)
  Using cached keras_cv_attention_models-1.0.13-py3-none-any.whl (118 kB)
  Using cached keras_cv_attention_models-1.0.12-py3-none-any.whl (116 kB)
  Using cached keras_cv_attention_models-1.0.11-py3-none-any.whl (116 kB)
  Using cached keras_cv_attention_models-1.0.10-py3-none-any.whl (112 kB)
  Using cached keras_cv_attention_models-1.0.9-py3-none-any.whl (111 kB)
  Using cached keras_cv_attention_models-1.0.8-py3-none-any.whl (107 kB)
  Using cached keras_cv_attention_models-1.0.7-py3-none-any.whl (102 kB)
  Using cached keras_cv_attention_models-1.0.6-py3-none-any.whl (98 kB)
  Using cached keras_cv_attention_models-1.0.4-py3-none-any.whl (99 kB)
  Using cached keras_cv_attention_models-1.0.3-py3-none-any.whl (84 kB)
ERROR: Cannot install keras-cv-attention-models==1.0.10, keras-cv-attention-models==1.0.11, keras-cv-attention-models==1.0.12, keras-cv-attention-models==1.0.13, keras-cv-attention-models==1.0.14, keras-cv-attention-models==1.0.15, keras-cv-attention-models==1.0.16, keras-cv-attention-models==1.0.17, keras-cv-attention-models==1.0.18, keras-cv-attention-models==1.0.19, keras-cv-attention-models==1.0.20, keras-cv-attention-models==1.0.21, keras-cv-attention-models==1.0.22, keras-cv-attention-models==1.0.3, keras-cv-attention-models==1.0.4, keras-cv-attention-models==1.0.6, keras-cv-attention-models==1.0.7, keras-cv-attention-models==1.0.8, keras-cv-attention-models==1.0.9, keras-cv-attention-models==1.1.0, keras-cv-attention-models==1.1.1, keras-cv-attention-models==1.1.10, keras-cv-attention-models==1.1.11, keras-cv-attention-models==1.1.12, keras-cv-attention-models==1.1.13, keras-cv-attention-models==1.1.14, keras-cv-attention-models==1.1.15, keras-cv-attention-models==1.1.16, keras-cv-attention-models==1.1.17, keras-cv-attention-models==1.1.18, keras-cv-attention-models==1.1.19, keras-cv-attention-models==1.1.2, keras-cv-attention-models==1.1.20, keras-cv-attention-models==1.1.3, keras-cv-attention-models==1.1.4, keras-cv-attention-models==1.1.5, keras-cv-attention-models==1.1.6, keras-cv-attention-models==1.1.7, keras-cv-attention-models==1.1.8, keras-cv-attention-models==1.1.9, keras-cv-attention-models==1.2.0, keras-cv-attention-models==1.2.1, keras-cv-attention-models==1.2.2, keras-cv-attention-models==1.2.3 and keras-cv-attention-models==1.2.4 because these package versions have conflicting dependencies.

The conflict is caused by:
    keras-cv-attention-models 1.2.4 depends on tensorflow
    keras-cv-attention-models 1.2.3 depends on tensorflow
    keras-cv-attention-models 1.2.2 depends on tensorflow
    keras-cv-attention-models 1.2.1 depends on tensorflow
    keras-cv-attention-models 1.2.0 depends on tensorflow
    keras-cv-attention-models 1.1.20 depends on tensorflow
    keras-cv-attention-models 1.1.19 depends on tensorflow
    keras-cv-attention-models 1.1.18 depends on tensorflow
    keras-cv-attention-models 1.1.17 depends on tensorflow
    keras-cv-attention-models 1.1.16 depends on tensorflow
    keras-cv-attention-models 1.1.15 depends on tensorflow
    keras-cv-attention-models 1.1.14 depends on tensorflow
    keras-cv-attention-models 1.1.13 depends on tensorflow
    keras-cv-attention-models 1.1.12 depends on tensorflow
    keras-cv-attention-models 1.1.11 depends on tensorflow
    keras-cv-attention-models 1.1.10 depends on tensorflow
    keras-cv-attention-models 1.1.9 depends on tensorflow
    keras-cv-attention-models 1.1.8 depends on tensorflow
    keras-cv-attention-models 1.1.7 depends on tensorflow
    keras-cv-attention-models 1.1.6 depends on tensorflow
    keras-cv-attention-models 1.1.5 depends on tensorflow
    keras-cv-attention-models 1.1.4 depends on tensorflow
    keras-cv-attention-models 1.1.3 depends on tensorflow
    keras-cv-attention-models 1.1.2 depends on tensorflow
    keras-cv-attention-models 1.1.1 depends on tensorflow
    keras-cv-attention-models 1.1.0 depends on tensorflow
    keras-cv-attention-models 1.0.22 depends on tensorflow
    keras-cv-attention-models 1.0.21 depends on tensorflow
    keras-cv-attention-models 1.0.20 depends on tensorflow
    keras-cv-attention-models 1.0.19 depends on tensorflow
    keras-cv-attention-models 1.0.18 depends on tensorflow
    keras-cv-attention-models 1.0.17 depends on tensorflow
    keras-cv-attention-models 1.0.16 depends on tensorflow
    keras-cv-attention-models 1.0.15 depends on tensorflow
    keras-cv-attention-models 1.0.14 depends on tensorflow
    keras-cv-attention-models 1.0.13 depends on tensorflow
    keras-cv-attention-models 1.0.12 depends on tensorflow
    keras-cv-attention-models 1.0.11 depends on tensorflow
    keras-cv-attention-models 1.0.10 depends on tensorflow
    keras-cv-attention-models 1.0.9 depends on tensorflow
    keras-cv-attention-models 1.0.8 depends on tensorflow
    keras-cv-attention-models 1.0.7 depends on tensorflow
    keras-cv-attention-models 1.0.6 depends on tensorflow
    keras-cv-attention-models 1.0.4 depends on tensorflow
    keras-cv-attention-models 1.0.3 depends on tensorflow

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

By changing the `setup.py` as suggested in the PR, I can install your package running the `pip install -U git+https://github.com/dcleres/keras_cv_attention_models` command. 

I know that this solution is not the solution yet. However, I have not investigated how to write the setup.py in a way where either `tensorflow` **or** `tensorflow-macos` are required. Maybe you already know how to do that. 

Thank you! 